### PR TITLE
Add modular frontend and FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # XYExcel
+
+This project demonstrates a small Excel analysis tool with a Python FastAPI backend and a Vue 3 frontend.
+
+## Backend
+
+The backend exposes an upload route and a WebSocket for commands.
+
+```bash
+pip install fastapi uvicorn pandas matplotlib openpyxl
+python backend/main.py
+```
+
+Commands supported over the WebSocket:
+- `sum <column>` – calculate column sum
+- `average <column>` – calculate column average
+- `plot <column>` – return a line plot as an image
+
+## Frontend
+
+Open `frontend/index.html` in a browser after starting the backend. The frontend is structured using Vue components loaded as ES modules.
+
+1. Upload an Excel file.
+2. Enter commands in the chat box.
+3. Text or image results are displayed in real time.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, UploadFile, WebSocket
+from fastapi.responses import HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
+
+from processor import ExcelProcessor
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+processor = ExcelProcessor()
+
+@app.post('/upload')
+async def upload(file: UploadFile):
+    data = await file.read()
+    processor.load(data)
+    return {'status': 'ok'}
+
+@app.websocket('/ws')
+async def websocket_endpoint(ws: WebSocket):
+    await ws.accept()
+    while True:
+        text = await ws.receive_text()
+        result = processor.execute(text)
+        await ws.send_json(result)
+
+if __name__ == '__main__':
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/backend/processor.py
+++ b/backend/processor.py
@@ -1,0 +1,40 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import base64
+from io import BytesIO
+
+class ExcelProcessor:
+    def __init__(self):
+        self.df = None
+
+    def load(self, file_bytes: bytes):
+        self.df = pd.read_excel(BytesIO(file_bytes))
+
+    def execute(self, command: str):
+        if self.df is None:
+            return {"type": "text", "data": "No file uploaded."}
+        parts = command.strip().split()
+        if not parts:
+            return {"type": "text", "data": "Empty command."}
+        action = parts[0].lower()
+        if action == 'sum' and len(parts) > 1:
+            col = parts[1]
+            if col in self.df.columns:
+                result = self.df[col].sum()
+                return {"type": "text", "data": f"Sum of {col}: {result}"}
+        if action == 'average' and len(parts) > 1:
+            col = parts[1]
+            if col in self.df.columns:
+                result = self.df[col].mean()
+                return {"type": "text", "data": f"Average of {col}: {result}"}
+        if action == 'plot' and len(parts) > 1:
+            col = parts[1]
+            if col in self.df.columns:
+                fig, ax = plt.subplots()
+                self.df[col].plot(kind='line', ax=ax)
+                buf = BytesIO()
+                plt.savefig(buf, format='png')
+                plt.close(fig)
+                data = base64.b64encode(buf.getvalue()).decode('utf-8')
+                return {"type": "image", "data": f"data:image/png;base64,{data}"}
+        return {"type": "text", "data": "Unsupported command."}

--- a/frontend/components/ChatApp.js
+++ b/frontend/components/ChatApp.js
@@ -1,0 +1,60 @@
+import ChatMessage from './ChatMessage.js';
+
+export default {
+    components: { ChatMessage },
+    data() {
+        return {
+            ws: null,
+            input: '',
+            messages: [],
+            file: null
+        };
+    },
+    mounted() {
+        this.connect();
+    },
+    methods: {
+        connect() {
+            this.ws = new WebSocket('ws://localhost:8000/ws');
+            this.ws.onmessage = (e) => {
+                const msg = JSON.parse(e.data);
+                if (msg.type === 'image') {
+                    this.messages.push({ role: 'bot', content: `<img src="${msg.data}" />`, isHtml: true });
+                } else {
+                    this.messages.push({ role: 'bot', content: msg.data });
+                }
+            };
+        },
+        async sendMessage() {
+            const text = this.input.trim();
+            if (!text || !this.ws) return;
+            this.messages.push({ role: 'user', content: text });
+            this.ws.send(text);
+            this.input = '';
+        },
+        uploadFile(event) {
+            this.file = event.target.files[0];
+        },
+        async sendFile() {
+            if (!this.file) return;
+            const form = new FormData();
+            form.append('file', this.file);
+            await fetch('/upload', { method: 'POST', body: form });
+            this.messages.push({ role: 'bot', content: 'File uploaded.' });
+        }
+    },
+    template: `
+        <div>
+            <h2>XYExcel Chat</h2>
+            <input type="file" @change="uploadFile" />
+            <button @click="sendFile">Upload</button>
+            <div class="messages">
+                <ChatMessage v-for="(m, i) in messages" :key="i" :message="m" />
+            </div>
+            <form @submit.prevent="sendMessage">
+                <input type="text" v-model="input" placeholder="Type your message" required>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+    `
+};

--- a/frontend/components/ChatMessage.js
+++ b/frontend/components/ChatMessage.js
@@ -1,0 +1,10 @@
+export default {
+    props: ['message'],
+    template: `
+        <div class="message">
+            <span :class="message.role">{{ message.role }}:</span>
+            <span v-if="message.isHtml" v-html="message.content"></span>
+            <span v-else>{{ message.content }}</span>
+        </div>
+    `
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>XYExcel Chat</title>
+    <link rel="stylesheet" href="style.css">
+    <script type="module" src="main.js"></script>
+</head>
+<body>
+    <div id="app"></div>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.prod.js';
+import ChatApp from './components/ChatApp.js';
+
+createApp(ChatApp).mount('#app');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,8 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+#app { max-width: 600px; margin: auto; }
+.messages { border: 1px solid #ccc; padding: 10px; min-height: 200px; margin-bottom: 10px; }
+.message { margin-bottom: 8px; }
+.user { font-weight: bold; }
+.bot { color: green; }
+input[type="text"] { width: calc(100% - 110px); padding: 8px; }
+button { padding: 8px 15px; }


### PR DESCRIPTION
## Summary
- restructure frontend into ES modules with ChatApp and ChatMessage components
- add FastAPI backend to upload Excel files and process commands
- document setup and usage in README

## Testing
- `python -m py_compile backend/main.py backend/processor.py`
